### PR TITLE
Add symbol-level debugging to valgrind/python-interpreter combo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ coverage.xml
 nosetests.xml
 
 # debug files
+*.dSYM/
 valgrind_stderr.txt
 both.txt
 impermium_only.txt

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ nosetests.xml
 # debug files
 *.dSYM/
 valgrind_stderr.txt
+valgrind_python_stderr.txt
 both.txt
 impermium_only.txt
 james_only.txt

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ memcheck_python: build_ext
 	valgrind --tool=memcheck --dsymutil=yes \
 		--leak-check=full --show-leak-kinds=all --track-origins=yes \
 		--suppressions=valgrind-python.supp \
-		env/bin/python scripts/testmem.py 2> val_out_leak.txt
+		env/bin/python scripts/testmem.py 2> valgrind_python_stderr.txt
 
 develop:
 	@echo "Installing for " `which pip`

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,9 @@ memcheck_cc: compare_against_impermium
 		$(COMPARE_BIN) $(TEST_FILE) 2> valgrind_stderr.txt
 
 memcheck_python: build_ext
-	valgrind --tool=memcheck --leak-check=full --suppressions=valgrind-python.supp \
+	valgrind --tool=memcheck --dsymutil=yes \
+		--leak-check=full --show-leak-kinds=all --track-origins=yes \
+		--suppressions=valgrind-python.supp \
 		env/bin/python scripts/testmem.py 2> val_out_leak.txt
 
 develop:

--- a/phraser/__init__.py
+++ b/phraser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 import collections
 from phraser.phraserext import PhraserExt

--- a/phraser/cc/pyext/phraserext.cpp
+++ b/phraser/cc/pyext/phraserext.cpp
@@ -173,7 +173,7 @@ PyObject* UnicodeFromUstring(const ustring& s) {
 PyObject* MakeDict(const vector<PyObject*>& keys,
                    const vector<PyObject*>& values)
 {
-    // Createa a Python dictionary from a vector pair of keys anbd values
+    // Create a Python dictionary from a vector pair of keys and values
     // Steals references to all members of the two input vectors
     //
     auto num_keys = keys.size();

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ phraser = Extension(
 
 setup(
     name='phraser',
-    version='0.1.2',
+    version='0.1.3',
     author='James Knighton',
     author_email='iamknighton@gmail.com',
     description='Detects phrases in English text',


### PR DESCRIPTION
When run with "--dsymutil=yes", valgrind/python-interpreter combo will show symbol-level output for your C extensions like so:

==50206==    by 0xEB211C: (anonymous namespace)::UnicodeFromUstring(std::__1::vector<unsigned int, std::__1::allocator<unsigned int> > const&) (phraserext.cpp:169)
==50206==    by 0xEB1303: (anonymous namespace)::PhraserExt_analyze((anonymous namespace)::PhraserExt_, _object_) (phraserext.cpp:220)

Code-level changes in this pull request don't fix anything, only remove what i thought was unnecessary code. Specifically, I thought it is unnecessary to add proper handling of missing keys since the options are to either (a) make it really convoluted and non-leaking or (b) make it leak on error.
