### PR TITLE
CircleCI integration + auto-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,7 @@ nuke: clean
 clean:
 	python setup.py clean
 	rm -rf dist build $(BIN_DIR)
-	find . -path ./env -prune -o -type f -name "*.pyc" -exec rm {} \;
-	find . -path ./env -prune -o -type f -name "*.so" -exec rm {} \;
+	find . -path ./env -prune -o -type f -regex '.*\.pyc' -or -regex '.*\.so' -exec rm {} \;
 
 CC_SOURCES = $(shell find $(SRC_ROOT) -name "*.cc")
 O_INTERMEDIATES := $(patsubst $(SRC_ROOT)/%,$(BUILD_DIR)/%,$(CC_SOURCES:.cc=.o))
@@ -126,8 +125,8 @@ memcheck_python: build_ext
 
 develop:
 	@echo "Installing for " `which pip`
-	pip uninstall $(PYMODULE) || true
-	python setup.py develop
+	-pip uninstall --yes $(PYMODULE)
+	pip install -e .
 
 .PHONY: build_ext
 build_ext phraser/phraserext.so: env

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,6 @@ dependencies:
 test:
   override:
     - make test
-  post:
-    - make package
 
 deployment:
   production:
@@ -25,4 +23,3 @@ deployment:
 general:
   artifacts:
     - "cover"
-    - "dist"

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,13 @@ test:
   post:
     - make package
 
+deployment:
+  production:
+    branch: master
+    commands:
+      - bash create_pypirc.sh
+      - make release
+
 general:
   artifacts:
     - "cover"

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,13 @@ dependencies:
   override:
     - make extras
 
+test:
+  override:
+    - make test
+  post:
+    - make package
+
 general:
   artifacts:
     - "cover"
     - "dist"
-
-test:
-  override:
-    - make test

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ dependencies:
   pre:
     - sudo apt-get update
     - sudo apt-get install g++-4.7
+    - sudo apt-get install libboost1.55-all-dev
   override:
     - make extras
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+dependencies:
+  cache_directories:
+    - "env"
+  pre:
+    - sudo apt-get update
+    - sudo apt-get install g++-4.7
+  override:
+    - make extras
+
+general:
+  artifacts:
+    - "cover"
+    - "dist"
+
+test:
+  override:
+    - make test

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   cache_directories:
     - "env"
   pre:
-    - sudo add-apt-repository ppa:boost-latest/ppa
+    - yes | sudo add-apt-repository ppa:boost-latest/ppa
     - sudo apt-get update
     - sudo apt-get install g++-4.7
     - sudo apt-get install libboost1.55-all-dev

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   cache_directories:
     - "env"
   pre:
+    - sudo add-apt-repository ppa:boost-latest/ppa
     - sudo apt-get update
     - sudo apt-get install g++-4.7
     - sudo apt-get install libboost1.55-all-dev

--- a/create_pypirc.sh
+++ b/create_pypirc.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat <<- EOF > ~/.pypirc
+[distutils]
+index-servers =
+    livefyre
+
+[livefyre]
+repository:https://pypi.livefyre.com
+username:$LF_PYPI_USERNAME
+password:$LF_PYPI_PASSWORD
+EOF

--- a/phraser/__init__.py
+++ b/phraser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.8'
+__version__ = '0.1.9'
 
 import collections
 from phraser.phraserext import PhraserExt

--- a/phraser/__init__.py
+++ b/phraser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.6'
+__version__ = '0.1.8'
 
 import collections
 from phraser.phraserext import PhraserExt

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ phraser = Extension(
 
 setup(
     name='phraser',
-    version='0.1.6',
+    version='0.1.8',
     author='James Knighton',
     author_email='iamknighton@gmail.com',
     description='Detects phrases in English text',

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ phraser = Extension(
 
 setup(
     name='phraser',
-    version='0.1.8',
+    version='0.1.9',
     author='James Knighton',
     author_email='iamknighton@gmail.com',
     description='Detects phrases in English text',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,18 @@
 from setuptools import setup, Extension, find_packages
+from setuptools.dist import Distribution
 from pkg_resources import resource_string
 import os
 import platform
+
+
+class BinaryDistribution(Distribution):
+    """
+    Subclass the setuptools Distribution to flip the purity flag to false.
+    See http://lucumr.pocoo.org/2014/1/27/python-on-wheels/
+    """
+    def is_pure(self):
+        # TODO: verify whether this is still necessary in Python v2.7
+        return False
 
 
 SRC_ROOT = 'phraser/'
@@ -107,7 +118,7 @@ else:
 
 if os.environ.get('CXX') == 'clang++':
     FLAGS = COMMON_BASE_FLAGS + CLANG_BASE_FLAGS + COMMON_LAPOS_FLAGS + \
-            CLANG_DISABLE_FLAGS + CLANG_LAPOS_FLAGS
+        CLANG_DISABLE_FLAGS + CLANG_LAPOS_FLAGS
 else:
     FLAGS = COMMON_BASE_FLAGS + COMMON_LAPOS_FLAGS
 
@@ -131,4 +142,5 @@ setup(
     packages=find_packages(exclude=['tests', 'scripts']),
     ext_modules=[phraser],
     long_description=resource_string(__name__, 'README.rst'),
+    distclass=BinaryDistribution,
 )


### PR DESCRIPTION
Turns out CircleCI supports automated deployment as well as `sudo apt-get install`, which lets us route around the whole Andrew Thomson problem. From now on, anything merged to `Livefyre:master` branch will be automatically deployed to `pypi.livefyre.com` as a binary wheel package after the tests are completed (provided that the version number has also been updated).

Note: we may still have to go back in the future to using Livefyre build server once we get our `lfconfig` cr*\* together.
